### PR TITLE
Add stylistic rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,40 @@ module.exports = {
     'require-jsdoc': 'off',
     // Require semicolons instead of ASI
     'semi': ['error', 'always'],
+    // Enforce consistent spacing before and after semicolons
+    'semi-spacing': ['error', { before: false, after: true }],
+    // Enforce location of semicolons
+    'semi-style': ['error', 'last'],
+    // Enfore consistent spacing before blocks
+    'space-before-blocks': 'error',
+    // Enforce consistent spacing before `function` definition
+    'space-before-function-paren': ['error', {
+      anonymous: 'always',
+      named: 'never',
+      asyncArrow: 'always'
+    }],
+    // Enforce consistent spacing inside parentheses
+    'space-in-parens': ['error', 'never'],
+    // TODO: Require spacing around infix operators
+    'space-infix-ops': 'off',
+    // Enforce consistent spacing before or after unary operators
+    'space-unary-ops': ['error', { words: true, nonwords: false }],
+    // Enforce consistent spacing after or in a comment
+    'spaced-comment': ['error', 'always', {
+      line: {
+        exceptions: ['-', '+'],
+        markers: ['=', '!']
+      },
+      block: {
+        exceptions: ['-', '+'],
+        markers: ['=', '!'],
+        balanced: true
+      }
+    }],
+    // Enforce spacing around colons of switch statements
+    'switch-colon-spacing': ['error', { after: true, before: false }],
+    // Disallow spacing between template tags and their literals
+    'template-tag-spacing': 'error',
 
     /*
      * ECMAScript 6

--- a/index.js
+++ b/index.js
@@ -204,18 +204,18 @@ module.exports = {
     }],
     // Enforce consistent spacing inside parentheses
     'space-in-parens': ['error', 'never'],
-    // TODO: Require spacing around infix operators
-    'space-infix-ops': 'off',
+    // Require spacing around infix operators
+    'space-infix-ops': 'error',
     // Enforce consistent spacing before or after unary operators
     'space-unary-ops': ['error', { words: true, nonwords: false }],
     // Enforce consistent spacing after or in a comment
     'spaced-comment': ['error', 'always', {
       line: {
-        exceptions: ['-', '+'],
+        exceptions: ['-', '+', '*'],
         markers: ['=', '!']
       },
       block: {
-        exceptions: ['-', '+'],
+        exceptions: ['-', '+', '*'],
         markers: ['=', '!'],
         balanced: true
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-omnious",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ESLint shareable config for the Omnious JavaScript style guide",
   "homepage": "https://github.com/omnious-dev/eslint-config-omnious",
   "author": "Omnious Dev Team <dev@omnious.com> (https://www.omnious.com)",


### PR DESCRIPTION
Stylistic 파트 s 이후 모든 룰들 검토하였어요!


semi | 세미콜론 꼭 붙이기
semi-spacing | 세미콜론 전 공백 X 후 공백 O
semi-style | 세미콜론은 Statement 뒤에
sort-keys | 오브젝트 내에 키 알파벳 정렬 => 룰 추가 안함
sort-vars | 변수 선언 알파벳 정렬 => 룰 추가 안함
space-before-blocks | {} 블록 전에 항상 공백 하나
space-before-function-paren | 함수 정의 블록 전 공백 하나 (named 함수 제외, airbnb랑 같음)
space-in-parens | () 안에 항상 공백 없음. airbnb랑 같음.
space-infix-ops | TODO로 넣음.
space-unary-ops | alphabet unary 연산자는 공백. nonalphabet은 공백 X
spaced-comment | 주석 시작 전에 공백. -, +, /, * 등 예외 케이스 둠
switch-colon-spacing | switch-case에서 case와 콜론 사이 공백 없음
template-tag-spacing | template tag 정의시 공백 X
unicode-bom | utf16 관련 룰 => 룰 추가 안함
wrap-regex | regex ()로 감싸기 => 룰 추가 안함

