### PR TITLE
Set minimum length of id property 1(previous: 2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ module.exports = {
     // Disallow spacing between function identifiers and their invocations
     'func-call-spacing': ['error', 'never'],
     // Enforce minimum and maximum identifier lengths
-    'id-length': ['error', { max: 64 }],
+    'id-length': ['error', { min: 1, max: 64 }],
     // Enforce consistent indentation
     // TODO: Apply more options
     'indent': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-omnious",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ESLint shareable config for the Omnious JavaScript style guide",
   "homepage": "https://github.com/omnious-dev/eslint-config-omnious",
   "author": "Omnious Dev Team <dev@omnious.com> (https://www.omnious.com)",


### PR DESCRIPTION
ID 프로퍼티의 최소 길이를 1로 지정하였어요. 관례적으로 쓰는 i, x, y, z 등에도 린트 에러가 발생하는 것을 막고자..